### PR TITLE
Include explicit `permissions` in the example & reusable workflows

### DIFF
--- a/.github/workflows/update-major-tag.yaml
+++ b/.github/workflows/update-major-tag.yaml
@@ -1,9 +1,22 @@
 name: Update Major Release Tag
 
+# Reusable workflow files must be in `.github/workflows/`. While it would be
+# easier to find this definition if it were at the root of the project, GitHub
+# Actions does not support running workflows from there.
+# <https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#calling-a-reusable-workflow>
+
 on:
   workflow_call:
   release:
     types: [published]
+
+# Note this doesn't grant the `contents: write` permission: the calling workflow
+# must do that. Document the need for it (& give up extra permissions the caller
+# may have granted unnecessarily).
+# <https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#supported-keywords-for-jobs-that-call-a-reusable-workflow>
+permissions:
+  # Retain permission to push tags.
+  contents: write
 
 jobs:
   update-tag:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # update-major-release-workflow
 
-A small shared workflow to bump major semver tag (ex `v1`) on a repository when
-a new release (ex. `v1.0.2`) is published. Example use:
+Bump the major semver tag (such as `v1`) on a repository when a new release (such as `v1.0.2`) is published. Example:
 
-```yaml
-# .github/workflows/update-major-tag.yaml
-
-name: Update Major Tag
+``` yaml
+# .github/workflows/release.yaml
+name: Release
 
 on:
   release:
     types: [published]
 
+permissions:
+  # Grant permission to push tags.
+  contents: write
+
 jobs:
-  tag:
+  update-major-tag:
     uses: secondlife/update-major-tag-workflow/.github/workflows/update-major-tag.yaml@v1
 ```


### PR DESCRIPTION
Nowadays GitHub CodeQL (available for free on public repositories) notes when workflows are missing explicit permissions, as in this project:

* https://github.com/secondlife/update-major-tag-workflow/security/code-scanning/2

Let's add explicit `permissions` to the reusable `.github/workflows/update-major-tag.yaml`, and suggest the use of explicit `permissions` in the readme example. Lg?